### PR TITLE
Update ShapedMekanismRecipe.java

### DIFF
--- a/src/main/java/mekanism/common/recipe/ShapedMekanismRecipe.java
+++ b/src/main/java/mekanism/common/recipe/ShapedMekanismRecipe.java
@@ -92,7 +92,7 @@ public class ShapedMekanismRecipe implements IRecipe
 
 		HashMap<Character, Object> itemMap = new HashMap<Character, Object>();
 
-		for(; idx < recipe.length; idx += 2)
+		for(; idx < recipe.length; idx += 1)
 		{
 			Character chr = (Character)recipe[idx];
 			Object in = recipe[idx + 1];


### PR DESCRIPTION
This should fix a bug where jei shows some items require 2 items in one slot